### PR TITLE
dxf: Center object in (0, 0)

### DIFF
--- a/lib/data/contour/modification/CenterOnOrigin.ts
+++ b/lib/data/contour/modification/CenterOnOrigin.ts
@@ -1,0 +1,43 @@
+import ContourPoints from "../ContourPoints";
+import Point from "../../Point";
+
+type BoundingRect = {
+  topLeft: Point;
+  width: number;
+  height: number;
+};
+
+const _boundingRect = (contour: ContourPoints): BoundingRect => {
+  const { points } = contour;
+  // find the min and max x and y values
+  let minX = points[0].x;
+  let maxX = points[0].x;
+  let minY = points[0].y;
+  let maxY = points[0].y;
+  points.forEach((point) => {
+    minX = Math.min(minX, point.x);
+    maxX = Math.max(maxX, point.x);
+    minY = Math.min(minY, point.y);
+    maxY = Math.max(maxY, point.y);
+  });
+  return {
+    topLeft: { x: minX, y: minY },
+    width: maxX - minX,
+    height: maxY - minY,
+  };
+};
+
+const _centerOnOrigin = (contour: ContourPoints) => {
+  return (): ContourPoints => {
+    const boundingRect = _boundingRect(contour);
+    const translateX = boundingRect.topLeft.x + boundingRect.width / 2;
+    const translateY = boundingRect.topLeft.y + boundingRect.height / 2;
+    return {
+      points: contour.points.map((point) => {
+        return { x: point.x - translateX, y: point.y - translateY };
+      }),
+    };
+  };
+};
+
+export default _centerOnOrigin;

--- a/lib/data/contour/modification/index.ts
+++ b/lib/data/contour/modification/index.ts
@@ -1,4 +1,5 @@
 import ContourPoints from "../ContourPoints";
+import _centerOnOrigin from "./CenterOnOrigin";
 import _centerPoints from "./CenterPoints";
 import { _crudApi, _crudListOnlyApi, _crudSingleOnlyApi } from "./crud";
 import _mirrorPointsOnXAxis from "./MirrorPointsOnXAxis";
@@ -12,6 +13,7 @@ type ModificationFunction = (
 
 const modificationApi = () => {
   return {
+    centerOnOrigin: _centerOnOrigin,
     centerPoints: _centerPoints,
     mirrorPointsOnXAxis: _mirrorPointsOnXAxis,
     scalePoints: _scalePoints,

--- a/lib/export/dxf/DownloadDxf.ts
+++ b/lib/export/dxf/DownloadDxf.ts
@@ -24,7 +24,7 @@ const asDxfFile = (
   paperDimensions: PaperDimensions
 ) => {
   const points = pointsOf(outline);
-  const contours = modifyContourList(points).centerPoints(paperDimensions);
+  const contours = modifyContourList(points).centerOnOrigin();
   const dxf = Dxf.from(contours, paperDimensions);
   return new Blob([dxf], {
     type: "image/x-dxf",

--- a/lib/export/dxf/DxfExport.ts
+++ b/lib/export/dxf/DxfExport.ts
@@ -32,7 +32,7 @@ const polyLineOf = (points: Point[], paperDimensions: PaperDimensions) => {
 
 const dxfPointOf = (point: Point, paperDimensions: PaperDimensions) => {
   const { x, y } = point;
-  return `10\n${x}\n20\n${paperDimensions.height - y}\n`;
+  return `10\n${x}\n20\n${y}\n`;
 };
 
 export default fromContours;


### PR DESCRIPTION
Since most cad usages will have pieces centered in the origin axis and only one outline is exported in the dxf, it makes sense to also center the outline in the axis.

This works by introducing a modification centerOnOrigin that computes a bounding box and translates polygon points according to its center.

Before:
![Before](https://github.com/user-attachments/assets/41e2526b-59f8-46e8-9767-3fb2b4405496)

After:
![After](https://github.com/user-attachments/assets/726123a0-6eef-4283-a7cf-995e870b7c53)
